### PR TITLE
Align MVP2 corpus with canonical TestHarness query shape

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,9 +155,13 @@ Package `helmsdeep/`:
     - **MVP1** "what treats disease X?" (`chemical-[treats]->disease`), disease
       sampled from size-tiered pools via `mvp1_heavy`/`mvp1_medium`/`mvp1_light`
       (10/15/25 = the 50% MVP1 half, tiered 20/30/50 within it).
-    - **MVP2** chemical⇄gene `biolink:affects` with object aspect/direction
-      qualifiers, both edge directions: `mvp2_chem_affects_gene` /
-      `mvp2_gene_affects_chem` (25/25), gene + qualifier sampled per request.
+    - **MVP2** chemical `biolink:affects` gene, with object aspect/direction
+      qualifiers on the gene. The edge is **always** oriented chemical(subject)→
+      gene(object) (matching the Translator TestHarness `generate_query.py`); the
+      two variants differ only by which endpoint is pinned —
+      `mvp2_chem_affects_gene` (pinned gene, open chemical) /
+      `mvp2_chem_affects_open_gene` (pinned chemical, open gene) (25/25). Aspect is
+      the canonical `activity_or_abundance`; direction + entity sampled per request.
   - **`PATHFINDER_CORPUS`** — the Pathfinder run type (ARA/ARS only, selected by
     `aras_pathfinder`/`ars_pathfinder`). `pathfinder_drug_disease` pins **two**
     endpoints (a drug + a disease, sampled per request from `CHEM_DISEASE_PAIRS`)
@@ -264,10 +268,13 @@ helmsdeep --targets ars_pathfinder  --host https://ars.ci.transltr.io/ars/api --
   is a `Timeout` failure.
 - **Inferred corpus mixes MVP1 + MVP2 and varies entities per request.** MVP1
   (`mvp1_heavy/medium/light`, treats-disease) samples a tiered disease; MVP2
-  (`mvp2_chem_affects_gene`/`mvp2_gene_affects_chem`, affects-gene with
-  qualifiers) samples a gene + qualifier combo. The per-request variation covers
-  the real cost surface and avoids warming caches. MVP1 medium and light share
-  the long-tail pool until calibrated (see Status & what's left).
+  (`mvp2_chem_affects_gene`/`mvp2_chem_affects_open_gene`, a chemical→gene
+  `affects` edge with the gene-pinned and chemical-pinned variants) samples the
+  pinned entity + direction. The edge orientation is always chemical(subject)→
+  gene(object) and the aspect qualifier is always `activity_or_abundance`. The
+  per-request variation covers the real cost surface and avoids warming caches.
+  MVP1 medium and light share the long-tail pool until calibrated (see Status &
+  what's left).
 - **Environments & TRAPI versions vary per service.** Endpoints live across
   `*.ci.transltr.io`, `*.test.transltr.io`, and prod, and individual services pin
   different TRAPI versions in their URL paths. Target deliberately.

--- a/helmsdeep/trapi_corpus.py
+++ b/helmsdeep/trapi_corpus.py
@@ -106,7 +106,26 @@ GENES = [
     "NCBIGene:7124",   # TNF
     "NCBIGene:3569",   # IL6
 ]
-_ASPECTS = ["activity", "abundance"]
+
+# Chemical pool for the pinned-chemical MVP2 variant ("what genes does chemical X
+# affect?"). The chemical side is otherwise an open answer set; this small curated
+# set of real CHEBI drug CURIEs is only used when the chemical is the pinned
+# endpoint. Swap/extend with chemicals your target service actually knows about.
+CHEMICALS = [
+    METFORMIN,    # CHEBI:6801
+    LEVODOPA,     # CHEBI:15765
+    DONEPEZIL,    # CHEBI:53289
+    ALBUTEROL,    # CHEBI:2549 (salbutamol)
+    "CHEBI:15365",  # aspirin
+    "CHEBI:5118",   # gefitinib
+    "CHEBI:45783",  # imatinib
+    "CHEBI:8382",   # prednisone
+]
+
+# Canonical MVP2 object-qualifier values (mirrors the Translator TestHarness
+# generate_query.py): the aspect is the combined `activity_or_abundance` value the
+# real MVP2 acceptance assets send; direction is increased/decreased.
+_ASPECT = "activity_or_abundance"
 _DIRECTIONS = ["increased", "decreased"]
 
 
@@ -190,9 +209,13 @@ def one_hop_lookup_open():
 #   MVP1  "what chemicals treat disease X?"  -- open chemical -[treats]-> disease.
 #         Cost tracks the pinned disease's answer-set size, so the disease is
 #         sampled per request from size-tiered pools (heavy/medium/light).
-#   MVP2  chemical <-> gene "affects" with object aspect/direction qualifiers
-#         ("what changes gene X's activity/abundance?" and the inverse). Both
-#         edge directions are generated; the gene + qualifier vary per request.
+#   MVP2  chemical -[affects]-> gene with object aspect/direction qualifiers on
+#         the gene. The edge is ALWAYS oriented chemical(subject) -> gene(object)
+#         (matching the Translator TestHarness generate_query.py); the two
+#         variants differ only in which endpoint is pinned -- pin the gene and
+#         leave the chemical open ("what chemicals affect gene X?"), or pin the
+#         chemical and leave the gene open ("what genes does chemical X affect?").
+#         The entity + direction vary per request.
 # ----------------------------------------------------------------------------
 def _inferred_treats(disease):
     """MVP1: open chemical -[treats, inferred]-> pinned disease."""
@@ -228,7 +251,10 @@ def mvp1_light():
 def _affects(subject_node, object_node, aspect, direction):
     """MVP2: an inferred `affects` edge with object aspect/direction qualifiers.
 
-    Qualifiers always describe the OBJECT node (the thing being changed).
+    The edge is always oriented chemical(subject) -> gene(object), so the object
+    node is the gene and the qualifiers always describe that gene. Only the two
+    qualifiers the reference emits are sent (object aspect + direction); the
+    `qualified_predicate` carried on real test assets is intentionally omitted.
     """
     return _qg(
         nodes={"n0": subject_node, "n1": object_node},
@@ -248,20 +274,27 @@ def _affects(subject_node, object_node, aspect, direction):
 
 
 def mvp2_chem_affects_gene():
-    """MVP2: what chemicals change a gene's activity/abundance? (chem -> gene)."""
+    """MVP2 (gene pinned): what chemicals change gene X's activity/abundance?
+
+    Open ChemicalEntity subject -> pinned Gene object; qualifiers on the gene.
+    """
     return _affects(
         {"categories": ["biolink:ChemicalEntity"]},                 # open subject
         {"ids": [random.choice(GENES)], "categories": ["biolink:Gene"]},  # pinned object
-        random.choice(_ASPECTS), random.choice(_DIRECTIONS),
+        _ASPECT, random.choice(_DIRECTIONS),
     )
 
 
-def mvp2_gene_affects_chem():
-    """MVP2 inverse: what chemicals' abundance does a gene change? (gene -> chem)."""
+def mvp2_chem_affects_open_gene():
+    """MVP2 (chemical pinned): what genes does chemical X affect?
+
+    Pinned ChemicalEntity subject -> open Gene object. Same chemical -> gene edge
+    orientation as the gene-pinned variant; qualifiers still describe the gene.
+    """
     return _affects(
-        {"ids": [random.choice(GENES)], "categories": ["biolink:Gene"]},  # pinned subject
-        {"categories": ["biolink:ChemicalEntity"]},                 # open object
-        "abundance", random.choice(_DIRECTIONS),   # chemicals have abundance, not activity
+        {"ids": [random.choice(CHEMICALS)], "categories": ["biolink:ChemicalEntity"]},  # pinned subject
+        {"categories": ["biolink:Gene"]},                           # open object
+        _ASPECT, random.choice(_DIRECTIONS),
     )
 
 
@@ -393,16 +426,17 @@ RETRIEVER_CORPUS = [
 
 # Shepherd (ARA): inferred (creative) mode, cache bypassed. An even MVP1/MVP2
 # split (50/50). MVP1 (treats-disease) keeps its tiered disease sampling
-# (heavy/medium/light = 20/30/50 within its half); MVP2 (affects-gene) covers
-# both edge directions evenly. Tune all weights to your real traffic mix.
+# (heavy/medium/light = 20/30/50 within its half); MVP2 (chemical -[affects]->
+# gene) covers both pinning variants evenly. Tune all weights to your traffic mix.
 SHEPHERD_CORPUS = [
     # MVP1 -- "what treats disease X?" (tiered by disease answer-set size): 50%.
     ("mvp1_heavy",  mvp1_heavy,  10),
     ("mvp1_medium", mvp1_medium, 15),
     ("mvp1_light",  mvp1_light,  25),
-    # MVP2 -- chemical<->gene "affects" with qualifiers, both directions: 50%.
-    ("mvp2_chem_affects_gene", mvp2_chem_affects_gene, 25),
-    ("mvp2_gene_affects_chem", mvp2_gene_affects_chem, 25),
+    # MVP2 -- chemical -[affects]-> gene with qualifiers, gene-pinned and
+    # chemical-pinned variants: 50%.
+    ("mvp2_chem_affects_gene",      mvp2_chem_affects_gene,      25),
+    ("mvp2_chem_affects_open_gene", mvp2_chem_affects_open_gene, 25),
 ]
 
 # ARS: also inferred queries (it fans out to the ARAs). Reuses the Shepherd


### PR DESCRIPTION
MVP2 affects queries now always orient the edge chemical(subject) -> gene (object), matching TranslatorSRI/TestHarness generate_query.py. The reversed gene->chemical builder (a shape no real MVP2 query uses, which can return empty and score as an ARS failure) is replaced by the reference's chemical-pinned / open-gene variant. The two variants now differ only in which endpoint is pinned; the gene is always the object and the qualifiers always describe it.

Also switch the object_aspect_qualifier to the canonical combined value 'activity_or_abundance' (the value real MVP2 acceptance assets send) and add a small curated CHEBI chemical pool for the pinned-chemical variant.