### PR TITLE
Report full ARS query wall-clock in Locust stats, not just the merge call

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,10 +258,14 @@ helmsdeep --targets ars_pathfinder  --host https://ars.ci.transltr.io/ars/api --
   the user path. The ARS poll loop uses `gevent.sleep`, **never** `time.sleep`.
 - **ARS submit/poll/merge is one logical measurement.** `_run_ars` issues several
   HTTP calls (named `ars_submit`/`ars_poll`/`ars_merge` — they show in Locust's
-  own table) but records exactly one `COLLECTOR.record` per logical query, with
-  latency = wall-clock submit→terminal. A `Done` that returns **0 results counts
-  as a failure** (and raises a red flag); a non-terminal status past `max_poll_s`
-  is a `Timeout` failure.
+  own table as per-step diagnostics) but records exactly one `COLLECTOR.record`
+  per logical query, with latency = wall-clock submit→terminal. It also fires a
+  single synthetic `ars_query` Locust request event carrying that same full
+  wall-clock, so Locust's native stats table shows the true per-query time
+  (otherwise the only ARS rows would be the individual sub-calls — e.g. the
+  `ars_merge` GET, which times just the final merge fetch, not the whole query).
+  A `Done` that returns **0 results counts as a failure** (and raises a red
+  flag); a non-terminal status past `max_poll_s` is a `Timeout` failure.
 - **Inferred corpus mixes MVP1 + MVP2 and varies entities per request.** MVP1
   (`mvp1_heavy/medium/light`, treats-disease) samples a tiered disease; MVP2
   (`mvp2_chem_affects_gene`/`mvp2_gene_affects_chem`, affects-gene with

--- a/README.md
+++ b/README.md
@@ -75,8 +75,11 @@ The `ars` target is asynchronous: each logical query is `POST /submit` → poll
 `GET /messages/{pk}?trace=y` (every `poll_interval_s`, capped at `max_poll_s`,
 default 15 min) until `status` is `Done`/`Error` → fetch `GET /messages/{merged_pk}`
 and count `fields.data.message.results`. Latency is the wall-clock submit→terminal
-time; one measurement is recorded per logical query (the submit/poll/merge calls
-appear separately in Locust's own table but aren't double-counted).
+time; one measurement is recorded per logical query. A single `ars_query` Locust
+request event carries that full wall-clock, so Locust's native stats table shows
+the true per-query time — the individual `ars_submit`/`ars_poll`/`ars_merge` calls
+also appear there as per-step diagnostics (e.g. `ars_merge` times only the final
+merge fetch, not the whole query), but aren't double-counted as the query time.
 
 Because the ARS is what real users hit, the run also captures health signals to
 flag silent downstream breakage, written to `<prefix>_ars_health.csv` and

--- a/helmsdeep/trapi_loadtest.py
+++ b/helmsdeep/trapi_loadtest.py
@@ -243,12 +243,30 @@ class TRAPIUser(HttpUser):
             latency_ms = resp.request_meta["response_time"] or 0.0
             COLLECTOR.record(qtype, latency_ms, failed)
 
+    def _record_ars(self, qtype, latency_ms, failed, exc_msg=None, **health):
+        """Record one logical ARS query: into the per-stage COLLECTOR (drives
+        HelmsDeep's own reports) AND as a single Locust request event named
+        'ars_query', so the native stats table shows the full submit->terminal
+        wall-clock -- not just the final ars_merge GET.
+        """
+        COLLECTOR.record(qtype, latency_ms, failed, **health)
+        self.environment.events.request.fire(
+            request_type="ARS",
+            name="ars_query",
+            response_time=latency_ms,
+            response_length=health.get("response_bytes") or 0,
+            exception=(exc_msg if failed else None),
+            context={"qtype": qtype},
+        )
+
     def _run_ars(self, qtype, payload):
         """ARS: submit -> poll /messages/{pk} until terminal -> fetch merged.
 
         Latency is wall-clock submit->terminal. One COLLECTOR.record per logical
-        query (the submit/poll/merge HTTP calls show separately in Locust's own
-        table but are not double-counted). A Done with 0 results is a failure.
+        query, plus one synthetic 'ars_query' Locust request event carrying that
+        same full wall-clock (the submit/poll/merge HTTP calls also show
+        separately in Locust's own table for diagnostics, but are not
+        double-counted as the query time). A Done with 0 results is a failure.
         """
         start = time.time()
 
@@ -262,7 +280,9 @@ class TRAPIUser(HttpUser):
         ) as resp:
             if resp.status_code != 201:
                 resp.failure(f"submit status {resp.status_code}")
-                COLLECTOR.record(qtype, _elapsed_ms(), True, status="SubmitError")
+                self._record_ars(qtype, _elapsed_ms(), True,
+                                 f"submit status {resp.status_code}",
+                                 status="SubmitError")
                 return
             try:
                 pk = (resp.json() or {}).get("pk")
@@ -270,7 +290,8 @@ class TRAPIUser(HttpUser):
                 pk = None
             if not pk:
                 resp.failure("no pk in submit response")
-                COLLECTOR.record(qtype, _elapsed_ms(), True, status="NoPK")
+                self._record_ars(qtype, _elapsed_ms(), True,
+                                 "no pk in submit response", status="NoPK")
                 return
             resp.success()
 
@@ -300,14 +321,18 @@ class TRAPIUser(HttpUser):
         # 3) Terminal handling.
         if status == "Done":
             result_count, nbytes = self._fetch_merged(merged_pk)
-            COLLECTOR.record(
+            self._record_ars(
                 qtype, _elapsed_ms(), failed=(result_count == 0),
+                exc_msg=("Done with 0 results" if result_count == 0 else None),
                 status="Done", result_count=result_count, response_bytes=nbytes,
             )
         elif status == "Error":
-            COLLECTOR.record(qtype, _elapsed_ms(), True, status="Error")
+            self._record_ars(qtype, _elapsed_ms(), True, "ARS Error status",
+                             status="Error")
         else:
-            COLLECTOR.record(qtype, _elapsed_ms(), True, status="Timeout")
+            self._record_ars(qtype, _elapsed_ms(), True,
+                             f"no terminal status within {MAX_POLL_S}s",
+                             status="Timeout")
 
     def _fetch_merged(self, merged_pk):
         """Fetch the merged message; return (result_count, response_bytes)."""


### PR DESCRIPTION
The ARS runner's submit/poll/merge HTTP calls each fired their own Locust request event (ars_submit/ars_poll/ars_merge), so Locust's native stats table only ever showed individual call timings -- the ars_merge row timed just the final merge GET (~5s), and no row represented the full submit->terminal wall-clock of a logical query (minutes).

HelmsDeep's own reports (stages.csv/by_qtype.csv/summary.json) were already correct since COLLECTOR.record gets the full _elapsed_ms(); the gap was only in Locust's native table. Add a _record_ars helper that, alongside the existing COLLECTOR.record, fires a single synthetic 'ars_query' request event carrying the full wall-clock latency (and marking failure on the submit/error/ timeout/zero-result paths). The per-step sub-call rows remain as diagnostics.

Update CLAUDE.md and README.md to document the new ars_query event.