### PR TITLE
Add stage-start timestamps and configurable inter-stage cooldown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,10 @@ Package `helmsdeep/`:
   (`kps`/`aras`/`ars` plus the Pathfinder run types `aras_pathfinder`/
   `ars_pathfinder`) to a component config: `label`, `endpoint`, `corpus`
   (key into the corpus module), `protocol` (`sync`/`async`), `implemented`, and
-  per-target `stages` + `p99_slo_ms`. Async targets (`ars`, `ars_pathfinder`) add
+  per-target `stages` + `p99_slo_ms` + an optional `cooldown_s` (a quiet gap
+  between stages — users ramp to 0 so slow in-flight queries drain into the stage
+  that launched them instead of bleeding into the next; defaults to 0, set on the
+  expensive ARA/ARS/Pathfinder targets). Async targets (`ars`, `ars_pathfinder`) add
   `messages_endpoint`, `poll_interval_s`, `max_poll_s`. The `*_pathfinder` targets
   reuse the ARA/ARS endpoints + protocols but point at the `pathfinder` corpus and
   ship a gentler ramp + looser SLO (pinned-two-endpoint path-finding is the
@@ -127,10 +130,18 @@ Package `helmsdeep/`:
 - **`trapi_loadtest.py`** — the measurement engine (Locust). The component under
   test is chosen by `LOADTEST_TARGET`; `ENDPOINT`, `CORPUS`, `STAGES`,
   `P99_SLO_MS`, and the async knobs (`PROTOCOL`, `MESSAGES_PATH`,
-  `POLL_INTERVAL_S`, `MAX_POLL_S`) are all derived from `config.TARGETS[...]`.
+  `POLL_INTERVAL_S`, `MAX_POLL_S`) plus `COOLDOWN_S` are all derived from
+  `config.TARGETS[...]`.
   - `StepLoad(LoadTestShape)` — drives the `stages` ramp and marks the active stage.
+    When `COOLDOWN_S` is set it inserts a drain gap between stages (`tick()`
+    returns 0 users in the gap and calls `COLLECTOR.end_active_stage()` to freeze
+    the just-finished stage's end time); an `@events.init` listener sets
+    `stop_timeout = REQUEST_TIMEOUT` so a slow in-flight query finishes rather than
+    being killed when users ramp to 0.
   - `StageCollector` / `COLLECTOR` — buckets every completed request into the
-    stage active when it *finished* (per-stage, per-`qtype`). `record()` also
+    stage active when it *finished* (per-stage, per-`qtype`). Records each stage's
+    wall-clock `stage_started` / `stage_ended` (the latter is `setdefault`, so a
+    cooldown freeze isn't overwritten by the next `mark_stage`). `record()` also
     takes optional ARS signals: `status`, `result_count`, `response_bytes`.
   - `_stage_stats()` — per-stage RPS, percentiles, error rate, Little's-Law
     concurrency. `_ars_stage_health()` — per-stage ARS health row.
@@ -138,9 +149,9 @@ Package `helmsdeep/`:
     blocking `POST`) or `_run_ars()` (submit → poll `/messages/{pk}` with
     `gevent.sleep` until `Done`/`Error`/timeout → `_fetch_merged()` counts
     `fields.data.message.results`). One `COLLECTOR.record` per logical query.
-  - `on_test_stop()` — finds the knee, writes `stages.csv` / `by_qtype.csv` /
-    `summary.json`, and (async only) `ars_health.csv` plus `red_flags` in the
-    summary + printed block.
+  - `on_test_stop()` — finds the knee, writes `stages.csv` (incl. a `stage_start`
+    ISO-8601-UTC column) / `by_qtype.csv` / `summary.json`, and (async only)
+    `ars_health.csv` plus `red_flags` in the summary + printed block.
 - **`trapi_corpus.py`** — the per-component query corpuses:
   - `_qg(nodes, edges, tier=None, bypass_cache=None)` — TRAPI envelope; adds
     scalar `parameters.tier` (KP-only) or top-level `bypass_cache` (ARA/ARS) only
@@ -248,6 +259,10 @@ helmsdeep --targets ars_pathfinder  --host https://ars.ci.transltr.io/ars/api --
 
 - **The shape owns concurrency.** Tune load by editing the per-target `stages`
   in `config.py`, not CLI flags.
+- **Cooldown drains, it doesn't bleed.** With `cooldown_s` set, the gap between
+  stages ramps users to 0; the just-finished stage's end time is frozen so its
+  `duration_s`/RPS reflect the active window, and a slow query still running
+  drains into *that* stage (via `stop_timeout`), keeping the next stage clean.
 - **Closed-loop load.** `TRAPIUser.wait_time = constant(0)` — no think time; users
   hammer the endpoint as fast as responses return.
 - **Don't trust Locust's blended aggregate during a ramp.** We bucket per stage in

--- a/README.md
+++ b/README.md
@@ -58,11 +58,18 @@ The load profile (users, spawn rate, duration) is driven by the `StepLoad` shape
 threshold are **per target** in `helmsdeep/config.py` (`stages` and
 `p99_slo_ms`), since cost profiles differ wildly by layer; edit them there.
 
+An optional per-target `cooldown_s` inserts a quiet gap **between** stages: users
+ramp to 0 so slow in-flight queries drain (counted under the stage that launched
+them) before the next stage starts clean, instead of bleeding into it. It defaults
+to 0 (cheap KP lookups don't bleed) and is set on the expensive ARA/ARS/Pathfinder
+targets.
+
 ## Outputs
 
 Written to the working directory by the standalone/master node:
 
-- `<prefix>_stages.csv` — one row per stage (overall metrics)
+- `<prefix>_stages.csv` — one row per stage (overall metrics), including a
+  `stage_start` column with the stage's wall-clock start time (ISO 8601 UTC)
 - `<prefix>_by_qtype.csv` — one row per (stage, query type)
 - `<prefix>_summary.json` — config (including which `target` was measured), all
   stages, and the chosen knee

--- a/helmsdeep/config.py
+++ b/helmsdeep/config.py
@@ -24,6 +24,11 @@ Fields:
   stages       step-load ramp: list of (users, spawn_rate, hold_seconds). Each
                stage should hold long enough for a stable measurement.
   p99_slo_ms   knee requires this layer's stage p99 <= this (ms)
+  cooldown_s   optional quiet gap BETWEEN stages (default 0). Users ramp to 0 so
+               slow in-flight queries drain and are counted under the stage that
+               launched them, rather than bleeding into the next stage. Set it on
+               the expensive layers (ARA/ARS/Pathfinder); cheap KP lookups don't
+               bleed, so they leave it at 0.
 
 Async (``ars``) targets add:
   messages_endpoint  base path for polling/merge: /messages/{pk}
@@ -70,6 +75,7 @@ TARGETS = {
             (40, 5, 600),  # 10 mins
         ],
         "p99_slo_ms": 210000,
+        "cooldown_s": 60,                 # drain slow queries between stages
     },
     "ars": {
         "label": "ARS",
@@ -90,6 +96,7 @@ TARGETS = {
             (40, 5, 600),  # 10 mins
         ],
         "p99_slo_ms": 240000,             # 4-min knee target (< max_poll_s)
+        "cooldown_s": 60,                 # drain slow queries between stages
     },
     # Pathfinder is its own run type (ARA + ARS only): it pins two endpoints and
     # asks for connecting paths -- the most intensive query class. Same endpoints
@@ -110,6 +117,7 @@ TARGETS = {
             (40, 5, 600),  # 10 mins
         ],
         "p99_slo_ms": 300000,             # 5-min knee target (vs 2 min for aras)
+        "cooldown_s": 60,                 # drain slow queries between stages
     },
     "ars_pathfinder": {
         "label": "ARS (Pathfinder)",
@@ -129,6 +137,7 @@ TARGETS = {
             (40, 5, 600),  # 10 mins
         ],
         "p99_slo_ms": 300000,            # 5-min knee target (< max_poll_s)
+        "cooldown_s": 60,                # drain slow queries between stages
     },
 }
 

--- a/helmsdeep/trapi_loadtest.py
+++ b/helmsdeep/trapi_loadtest.py
@@ -68,6 +68,10 @@ MESSAGES_PATH = _TGT.get("messages_endpoint", "/messages")
 POLL_INTERVAL_S = _TGT.get("poll_interval_s", 10)
 MAX_POLL_S = _TGT.get("max_poll_s", 900)
 
+# Optional quiet gap between stages (users ramp to 0) so slow in-flight queries
+# drain into the stage that launched them instead of bleeding into the next one.
+COOLDOWN_S = _TGT.get("cooldown_s", 0)
+
 CSV_PREFIX = os.environ.get("LOCUST_CSV_PREFIX", "trapi_run")
 
 # Weighted, flattened corpus for O(1)-ish random selection.
@@ -101,9 +105,16 @@ class StageCollector:
 
     def mark_stage(self, idx):
         if idx != self.stage_idx:
-            self.stage_ended[self.stage_idx] = time.time()
+            # setdefault (not =) so a cooldown that already froze this stage's end
+            # time isn't overwritten when the next stage begins.
+            self.stage_ended.setdefault(self.stage_idx, time.time())
         self.stage_idx = idx
         self.stage_started.setdefault(idx, time.time())
+
+    def end_active_stage(self):
+        # Called at cooldown start: freeze the just-finished stage's end time so
+        # its duration reflects the active-load window, not the drain period.
+        self.stage_ended.setdefault(self.stage_idx, time.time())
 
     def record(self, qtype, latency_ms, failed, *,
                status=None, result_count=None, response_bytes=None):
@@ -151,10 +162,15 @@ def _stage_stats(idx, qtype):
     dur = max(ended - started, 1e-9) if started else 1e-9
     rps = n_req / dur
     mean = sum(lat) / len(lat) if lat else 0.0
+    # Wall-clock stage start, ISO 8601 UTC (e.g. 2026-06-10T14:30:05Z).
+    stage_start = (
+        time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(started)) if started else ""
+    )
     return {
         "stage": idx,
         "qtype": qtype,
         "users": STAGES[idx][0] if idx < len(STAGES) else None,
+        "stage_start": stage_start,
         "requests": n_req,
         "errors": n_err,
         "error_rate": (n_err / n_req) if n_req else 0.0,
@@ -356,6 +372,15 @@ class TRAPIUser(HttpUser):
                 return 0, nbytes
 
 
+# When cooldown is enabled, stages ramp down to 0 users between holds. Set a
+# stop_timeout so a user finishing its (possibly very slow) current query is
+# allowed to complete and be counted, rather than killed mid-request.
+@events.init.add_listener
+def _set_stop_timeout(environment, **_kw):
+    if COOLDOWN_S:
+        environment.stop_timeout = REQUEST_TIMEOUT
+
+
 # ----------------------------------------------------------------------------
 # Step-load shape. tick() returns (user_count, spawn_rate) or None to stop.
 # It also tells the collector which stage is active.
@@ -363,11 +388,16 @@ class TRAPIUser(HttpUser):
 class StepLoad(LoadTestShape):
     def __init__(self):
         super().__init__()
-        self._bounds = []
+        self._bounds = []      # (start, end, idx) active-load windows
+        self._cooldowns = []   # (start, end) drain gaps between stages
         t = 0
+        n = len(STAGES)
         for i, (_users, _rate, hold) in enumerate(STAGES):
             self._bounds.append((t, t + hold, i))
             t += hold
+            if COOLDOWN_S and i < n - 1:   # gap BETWEEN stages, not after the last
+                self._cooldowns.append((t, t + COOLDOWN_S))
+                t += COOLDOWN_S
         self._total = t
 
     def tick(self):
@@ -379,6 +409,13 @@ class StepLoad(LoadTestShape):
                 COLLECTOR.mark_stage(idx)
                 users, rate, _hold = STAGES[idx]
                 return (users, rate)
+        # In a cooldown gap: ramp users to 0 so slow in-flight queries drain into
+        # the just-finished stage (its end time is frozen here) rather than the
+        # next one. stop_timeout (set at init) lets those queries finish.
+        for start, end in self._cooldowns:
+            if start <= run_time < end:
+                COLLECTOR.end_active_stage()
+                return (0, max(1, len(STAGES)))
         return None
 
 
@@ -449,7 +486,7 @@ def on_test_stop(environment, **_kw):
             prev = h
 
     # Write overall CSV.
-    fields = ["stage", "users", "requests", "errors", "error_rate",
+    fields = ["stage", "users", "stage_start", "requests", "errors", "error_rate",
               "duration_s", "rps", "mean_ms", "p50_ms", "p95_ms", "p99_ms",
               "concurrency"]
     with open(f"{CSV_PREFIX}_stages.csv", "w") as f:


### PR DESCRIPTION
- stages.csv now carries a stage_start column (ISO 8601 UTC) for when each stage began, sourced from the wall-clock time the collector already tracked.
- New optional per-target cooldown_s knob inserts a quiet gap between stages: StepLoad ramps users to 0 so slow in-flight queries drain into the stage that launched them (stop_timeout lets them finish) instead of bleeding into the next stage. Defaults to 0; set on the expensive ARA/ARS/Pathfinder targets.

The collector's stage end-time is now frozen at cooldown start (setdefault) so duration_s reflects the active-load window, not the drain period.